### PR TITLE
feat(web): add routing, pages, and API client

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,35 +1,22 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
+import { Routes, Route } from 'react-router-dom'
 import './App.css'
+import { NavBar } from './components/NavBar'
+import { Container } from './components/Container'
+import Home from './pages/Home'
+import Applications from './pages/Applications'
+import NotFound from './pages/NotFound'
 
-function App() {
-  const [count, setCount] = useState(0)
-
+export default function App() {
   return (
     <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
+      <NavBar />
+      <Container>
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/applications" element={<Applications />} />
+          <Route path="*" element={<NotFound />} />
+        </Routes>
+      </Container>
     </>
   )
 }
-
-export default App

--- a/apps/web/src/components/Container.tsx
+++ b/apps/web/src/components/Container.tsx
@@ -1,0 +1,15 @@
+import type { PropsWithChildren } from 'react'
+
+export function Container({ children }: PropsWithChildren) {
+  return (
+    <main
+      style={{
+        maxWidth: 1280,
+        margin: '0 auto',
+        padding: '2rem 1rem',
+      }}
+    >
+      {children}
+    </main>
+  )
+}

--- a/apps/web/src/components/NavBar.tsx
+++ b/apps/web/src/components/NavBar.tsx
@@ -1,0 +1,53 @@
+import { Link, NavLink } from 'react-router-dom'
+
+export function NavBar() {
+  return (
+    <header
+      style={{
+        borderBottom: '1px solid #333',
+        background: 'transparent',
+        position: 'sticky',
+        top: 0,
+        zIndex: 50,
+      }}
+    >
+      <nav
+        style={{
+          maxWidth: 1280,
+          margin: '0 auto',
+          padding: '1rem',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: '1rem',
+        }}
+      >
+        <Link to="/" style={{ fontWeight: 700, textDecoration: 'none' }}>
+          InternTrackr
+        </Link>
+
+        <div style={{ display: 'flex', gap: '1rem' }}>
+          <NavLink
+            to="/"
+            style={({ isActive }) => ({
+              textDecoration: 'none',
+              fontWeight: isActive ? 700 : 500,
+            })}
+          >
+            Home
+          </NavLink>
+
+          <NavLink
+            to="/applications"
+            style={({ isActive }) => ({
+              textDecoration: 'none',
+              fontWeight: isActive ? 700 : 500,
+            })}
+          >
+            Applications
+          </NavLink>
+        </div>
+      </nav>
+    </header>
+  )
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,0 +1,21 @@
+const BASE_URL = import.meta.env.VITE_API_BASE_URL as string | undefined
+
+function getBaseUrl() {
+  if (!BASE_URL) {
+    return ''
+  }
+  return BASE_URL.replace(/\/+$/, '')
+}
+
+export async function apiGet<T>(path: string, init?: RequestInit): Promise<T> {
+  const url = `${getBaseUrl()}${path}`
+  const res = await fetch(url, {
+    ...init,
+    headers: { accept: 'application/json', ...(init?.headers || {}) },
+  })
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    throw new Error(`GET ${path} failed: ${res.status} ${text}`)
+  }
+  return res.json() as Promise<T>
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
 import './index.css'
-import App from './App.tsx'
+import App from './App'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>,
 )

--- a/apps/web/src/pages/Applications.tsx
+++ b/apps/web/src/pages/Applications.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useState } from 'react'
+import { apiGet } from '../lib/api'
+import type { AppItem } from '../types'
+
+export default function Applications() {
+  const [items, setItems] = useState<AppItem[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let mounted = true
+
+    async function load() {
+      setLoading(true)
+      setError(null)
+      try {
+        const data = await apiGet<AppItem[]>('/applications')
+        if (mounted) setItems(data)
+      } catch (err: any) {
+        if (mounted) setError(err?.message ?? 'Failed to load applications')
+      } finally {
+        if (mounted) setLoading(false)
+      }
+    }
+
+    load()
+    return () => {
+      mounted = false
+    }
+  }, [])
+
+  if (loading) return <p>Loading applications…</p>
+  if (error) return <p style={{ color: 'tomato' }}>{error}</p>
+  if (!items || items.length === 0) {
+    return (
+      <section>
+        <h1>Applications</h1>
+        <p>No applications yet. Add one in the API or UI (coming next).</p>
+      </section>
+    )
+  }
+
+  return (
+    <section>
+      <h1 style={{ marginBottom: '1rem' }}>Applications</h1>
+      <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'grid', gap: '0.75rem' }}>
+        {items.map((app) => (
+          <li
+            key={app.id}
+            style={{
+              border: '1px solid #333',
+              borderRadius: 12,
+              padding: '1rem',
+              display: 'grid',
+              gap: '0.25rem',
+            }}
+          >
+            <div style={{ fontWeight: 700 }}>
+              {app.company} — {app.role}
+            </div>
+            {app.deadline && (
+              <div style={{ opacity: 0.8 }}>
+                Deadline: {new Date(app.deadline).toLocaleString()}
+              </div>
+            )}
+            {app.status && <div>Status: {app.status}</div>}
+            {app.link && (
+              <div>
+                <a href={app.link} target="_blank" rel="noreferrer">
+                  Job link
+                </a>
+              </div>
+            )}
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/apps/web/src/pages/Home.tsx
+++ b/apps/web/src/pages/Home.tsx
@@ -1,0 +1,12 @@
+export default function Home() {
+    return (
+      <section>
+        <h1 style={{ marginBottom: '0.5rem' }}>Welcome 👋</h1>
+        <p>
+          Track your internship applications, see deadlines at a glance, and get
+          reminders. Use the Applications page to get started.
+        </p>
+      </section>
+    )
+  }
+  

--- a/apps/web/src/pages/NotFound.tsx
+++ b/apps/web/src/pages/NotFound.tsx
@@ -1,0 +1,10 @@
+import { Link } from 'react-router-dom'
+
+export default function NotFound() {
+  return (
+    <section>
+      <h1>404 — Not Found</h1>
+      <p>That page doesn't exist. Try the <Link to="/">Home</Link> page.</p>
+    </section>
+  )
+}

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -1,0 +1,9 @@
+export type AppItem = {
+    id: string
+    company: string
+    role: string
+    link?: string
+    deadline?: string // ISO string
+    status?: 'SAVED' | 'APPLIED' | 'OA' | 'INTERVIEW' | 'REJECTED' | 'OFFER'
+  }
+  

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "workspaces": [
         "apps/*"
       ],
+      "dependencies": {
+        "react-router-dom": "^7.9.3"
+      },
       "devDependencies": {
         "eslint": "^9.9.0",
         "eslint-config-prettier": "^9.1.0",
@@ -6148,9 +6151,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.9.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.9.1.tgz",
-      "integrity": "sha512-pfAByjcTpX55mqSDGwGnY9vDCpxqBLASg0BMNAuMmpSGESo/TaOUG6BllhAtAkCGx8Rnohik/XtaqiYUJtgW2g==",
+      "version": "7.9.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.9.3.tgz",
+      "integrity": "sha512-4o2iWCFIwhI/eYAIL43+cjORXYn/aRQPgtFRRZb3VzoyQ5Uej0Bmqj7437L97N9NJW4wnicSwLOLS+yCXfAPgg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -6170,12 +6173,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.9.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.9.1.tgz",
-      "integrity": "sha512-U9WBQssBE9B1vmRjo9qTM7YRzfZ3lUxESIZnsf4VjR/lXYz9MHjvOxHzr/aUm4efpktbVOrF09rL/y4VHa8RMw==",
+      "version": "7.9.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.9.3.tgz",
+      "integrity": "sha512-1QSbA0TGGFKTAc/aWjpfW/zoEukYfU4dc1dLkT/vvf54JoGMkW+fNA+3oyo2gWVW1GM7BxjJVHz5GnPJv40rvg==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.9.1"
+        "react-router": "7.9.3"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
     "*.{json,md,css,scss}": [
       "prettier --write"
     ]
+  },
+  "dependencies": {
+    "react-router-dom": "^7.9.3"
   }
 }


### PR DESCRIPTION
Why: Need basic web setup to show pages and connect to API

What changed:
- Added React Router with Home, Applications, NotFound pages
- Added NavBar and Container components
- Created api client + AppItem type
- Connected Applications page to /applications endpoint

Testing:
- npm run dev -w apps/web
- Verified Home routes load (Applications does not)
- Verified API fetch shows list or error message

Impact/Risk:
- Requires VITE_API_BASE_URL set in env
- No DB migrations or schema changes

Checklist:
- Builds locally
- Lints + formats clean
- Tested happy path
- No stray console logs
