### PR TITLE
chore: update URL references from vercel domain to interntrakr.com

### DIFF
--- a/infra/terraform/envs/prod.tfvars
+++ b/infra/terraform/envs/prod.tfvars
@@ -6,6 +6,6 @@ ecr_repo_name = "api"
 
 lambda_api_base_url     = "https://interntrackr-api-production.up.railway.app"
 lambda_ses_from_email   = "alerts@seralaboratories.com"
-lambda_web_app_url      = "https://interntrackr-web.vercel.app"
+lambda_web_app_url      = "https://interntrakr.com"
 lambda_alert_window_days = 7
 lambda_schedule_expression = "cron(0 14 * * ? *)"

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -45,7 +45,7 @@ variable "lambda_ses_from_email" {
 variable "lambda_web_app_url" {
   type        = string
   description = "Frontend web application URL for email CTA"
-  default     = "https://interntrackr-web.vercel.app"
+  default     = "https://interntrakr.com"
 }
 
 variable "lambda_alert_window_days" {

--- a/serverless/README.md
+++ b/serverless/README.md
@@ -16,11 +16,11 @@ Triggered nightly by EventBridge cron schedule.
 
 ### Optional
 
-| Variable            | Description                       | Default                               |
-| ------------------- | --------------------------------- | ------------------------------------- |
-| `SES_REGION`        | AWS region for SES                | `us-west-1`                           |
-| `ALERT_WINDOW_DAYS` | Days ahead to check for deadlines | `7`                                   |
-| `WEB_APP_URL`       | Frontend URL for email CTA button | `https://interntrackr-web.vercel.app` |
+| Variable            | Description                       | Default                   |
+| ------------------- | --------------------------------- | ------------------------- |
+| `SES_REGION`        | AWS region for SES                | `us-west-1`               |
+| `ALERT_WINDOW_DAYS` | Days ahead to check for deadlines | `7`                       |
+| `WEB_APP_URL`       | Frontend URL for email CTA button | `https://interntrakr.com` |
 
 ## Architecture
 
@@ -53,7 +53,7 @@ export API_BASE_URL=https://interntrackr-api-production.up.railway.app
 export INTERNAL_API_KEY=your-secret-key
 export SES_FROM_EMAIL=alerts@yourdomain.com
 export SES_REGION=us-west-1
-export WEB_APP_URL=https://interntrackr-web.vercel.app
+export WEB_APP_URL=https://interntrakr.com
 
 # Run locally (requires AWS credentials for SES)
 npm run build

--- a/serverless/alerts-lambda/.env.example
+++ b/serverless/alerts-lambda/.env.example
@@ -3,4 +3,4 @@ INTERNAL_API_KEY=your-secret-key-here
 SES_FROM_EMAIL=alerts@yourdomain.com
 SES_REGION=us-west-1
 ALERT_WINDOW_DAYS=7
-WEB_APP_URL=https://interntrackr-web.vercel.app
+WEB_APP_URL=https://interntrakr.com

--- a/serverless/alerts-lambda/src/email-templates.ts
+++ b/serverless/alerts-lambda/src/email-templates.ts
@@ -163,7 +163,7 @@ export function buildEmailHtml(userData: UserEmailData): string {
               <p style="margin: 0 0 16px 0; color: ${MUTED_COLOR}; font-size: 14px;">
                 Don't miss these deadlines!
               </p>
-              <a href="${process.env.WEB_APP_URL || "https://interntrakr-web.vercel.app"}" style="display: inline-block; background: ${BRAND_COLOR}; color: white; padding: 12px 24px; border-radius: 8px; text-decoration: none; font-weight: 600; font-size: 16px;">
+              <a href="${process.env.WEB_APP_URL || "https://interntrakr.com"}" style="display: inline-block; background: ${BRAND_COLOR}; color: white; padding: 12px 24px; border-radius: 8px; text-decoration: none; font-weight: 600; font-size: 16px;">
                 Open InternTrackr
               </a>
             </td>
@@ -211,7 +211,7 @@ ${applicationList}
 
 Don't miss these deadlines!
 
-Open InternTrackr: https://interntrakr-web.vercel.app/
+Open InternTrackr: https://interntrakr.com
 
 ---
 You're receiving this because you have upcoming application deadlines.


### PR DESCRIPTION
# Summary
Updates URL references across Terraform + serverless config and email templates from the Vercel preview domain to the production domain (`interntrakr.com`).

# Changes
## Infra / Terraform
- `infra/terraform/envs/prod.tfvars`: set `lambda_web_app_url` to `https://interntrakr.com`
- `infra/terraform/variables.tf`: update default `lambda_web_app_url` to `https://interntrakr.com`

## Serverless / Alerts Lambda
- `serverless/README.md`: update `WEB_APP_URL` defaults + examples to `https://interntrakr.com`
- `serverless/alerts-lambda/.env.example`: update `WEB_APP_URL` to `https://interntrakr.com`
- `serverless/alerts-lambda/src/email-templates.ts`:
  - update fallback CTA link to `https://interntrakr.com`
  - update plaintext “Open InternTrackr” link to `https://interntrakr.com`

# Testing
- N/A (config + string updates only)

# Breaking Changes
None.